### PR TITLE
preserve habit-style max repeaters and include in to_string()

### DIFF
--- a/lib/Org/Element/Timestamp.pm
+++ b/lib/Org/Element/Timestamp.pm
@@ -20,6 +20,7 @@ for (@attrs) {
 }
 
 has _repeater => (is => 'rw'); # stores the raw repeater spec, for as_string
+has _repeater_max => (is => 'rw'); # stores the raw repeater spec, for as_string
 has _warning_period => (is => 'rw'); # raw warning period spec, for as_string
 has _is_parsed => (is => 'rw');
 
@@ -60,6 +61,10 @@ sub as_string {
              $self->_repeater ? (
                  " ",
                  $self->_repeater,
+                 $self->_repeater_max ? (
+                     "/",
+                     $self->_repeater_max,
+                 ) : (),
              ) : (),
              $self->_warning_period ? (
                  " ",
@@ -101,8 +106,10 @@ sub _parse_timestamp {
                          (?<repeater_interval> $num_re)
                          (?<repeater_unit> [dwmy])
                      )
-                     (?:\/(?<repeater_interval_max> $num_re)
+                     \/?(?<repeater_max>
+                     (?:(?<repeater_interval_max> $num_re)
                          (?<repeater_unit_max> [dwmy]))?
+                     )
                  )?
                  (?:\s+(?<warning_period>
                          -
@@ -169,6 +176,7 @@ sub _parse_timestamp {
         }
         $self->recurrence($r);
         $self->_repeater($+{repeater});
+        $self->_repeater_max($+{repeater_max});
     }
 
     if ($+{warning_period}) {

--- a/t/timestamp.t
+++ b/t/timestamp.t
@@ -122,15 +122,33 @@ test_parse(
 [2011-03-23 Wed 10:12 +1d/2d]
 [2011-03-23 Wed 10:12 +1w/10d]
 [2011-03-23 Wed 10:12-11:23 +2w/3w]
+[2011-03-23 Wed 10:12 +2w/3w -1d]
 _
-    num => 3,
+    num => 4,
     test_after_parse => sub {
         my %args  = @_;
         my $doc   = $args{result};
         my $elems = $args{elements};
         is($elems->[0]->_repeater, "+1d", "[0] _repeater");
+        is($elems->[0]->_repeater_max, "2d", "[0] _repeater_max");
+        delete $elems->[0]->{_str};  # force re-build of string
+        is($elems->[0]->as_string, "[2011-03-23 Wed 10:12 +1d/2d]", "[0] as_string");
+
         is($elems->[1]->_repeater, "+1w", "[1] _repeater");
+        is($elems->[1]->_repeater_max, "10d", "[1] _repeater_max");
+        delete $elems->[1]->{_str};  # force re-build of string
+        is($elems->[1]->as_string, "[2011-03-23 Wed 10:12 +1w/10d]", "[1] as_string");
+
         is($elems->[2]->_repeater, "+2w", "[2] _repeater");
+        is($elems->[2]->_repeater_max, "3w", "[2] _repeater_max");
+        delete $elems->[2]->{_str};  # force re-build of string
+        is($elems->[2]->as_string, "[2011-03-23 Wed 10:12-11:23 +2w/3w]", "[2] as_string");
+
+        is($elems->[3]->_repeater, "+2w", "[3] _repeater");
+        is($elems->[3]->_repeater_max, "3w", "[3] _repeater_max");
+        is($elems->[3]->_warning_period, "-1d", "[3] _warning_period");
+        delete $elems->[3]->{_str};  # force re-build of string
+        is($elems->[3]->as_string, "[2011-03-23 Wed 10:12 +2w/3w -1d]", "[3] as_string");
 
         ok($elems->[0]->recurrence->isa('DateTime::Set::ICal'),
            "[0] recurrence");


### PR DESCRIPTION
Here's a fix for the to_string() method for habit-style max repeater values.

I wasn't sure how to associate that with the existing recurrence attribute or if a separate DateTime::Event::Recurrence object should be created.  The existing attribute is private, so I did not add it to the documentation.  If you know what you'd like to see done there, let me know and I'd be happy to work on a patch.

wu
