### PR TITLE
Fix to work with Perl v5.22 changes

### DIFF
--- a/lib/Org/Document.pm
+++ b/lib/Org/Document.pm
@@ -5,6 +5,7 @@ use locale;
 use Log::Any '$log';
 use Moo;
 use experimental 'smartmatch';
+no if $] ge 5.021_006, warnings => "locale";
 extends 'Org::Element';
 
 use Time::HiRes qw(gettimeofday tv_interval);

--- a/lib/Org/Element/Timestamp.pm
+++ b/lib/Org/Element/Timestamp.pm
@@ -7,6 +7,7 @@ use 5.010;
 use locale;
 use utf8;
 use Moo;
+no if $] ge 5.021_006, warnings => "locale";
 extends 'Org::Element';
 with 'Org::Element::InlineRole';
 


### PR DESCRIPTION
Perl v5.22 is adding warnings about problematic locale usage.  These
warnings have been in blead for some time, and have led to failures in
the test suite for Org::Parser:

https://rt.perl.org/Ticket/Display.html?id=123527

It turns out that there were bugs in blead which caused the warnings to
be raised inappropriately at times.  These were fixed by commit

http://perl5.git.perl.org/perl.git/commit/008e8e82d7383361068156624879df7566121878

However, I believe it is still possible for the Org::Parser test suite
to show errors under some circumstances.  This commit eliminates those,
though I'm not sure it is the approach you may want to take.

A bit of background:  Most of Org::Parser is within the scope of
'use locale'.  Most locales that Perl 5 supports are single-byte
locales, meaning only characters whose ordinals are 0..255 are legal.
In the case of the C locale, only characters from 0..127 are defined.
Perl 5 does support one multi-byte locale: UTF-8.

Some of the tests in Org::Parser use characters above 255, assuming that
the locale is UTF-8, and as far as I could determine, they don't verify
this assumption.  In many instances, making this assumption leads to no
ill-effects, but not always, and that is why the warnings have been
added to blead.  These tests don't appear to be adversely affected when
the assumption is false, but real code could be.

What this commit does is to turn off these warnings, so the behavior of
Perl is the same as in prior releases in this regard.

But doing this may cause real errors to not be flagged.  One of the
issues that caused us to add the warnings is that the same character
could otherwise be represented by two different code points.  For
example, in a Greek locale, the letter π (pi) could be both 0xF0 and
0x3C0.  This could easily lead to bugs in unsuspecting applications.
This commit essentially just hides these problems.

Another option to get the tests to pass would be for the test suite to
skip the tests that assume a UTF-8 locale, when the locale they are run
under isn't UTF-8.  If you prefer, I could submit a patch to do that
instead.  It is even possible to have the test suite scan for UTF-8
locales on the current system, and to change the test locale to one of
those if any is found, and to otherwise skip the tests.  This is done in
Perl's internal test suite, but it seems to me to be rather
over-complicated for this particular use.

Another option is to turn off the warning in the test suite by trapping
it using $SIG{__WARN__}.  I actually think this may be the best option,
but I don't know the nuances of how your module is used to be able to
make that determination myself.  This option would just ignore the
particular new warning messages that are causing failures, and it would
do it only for your test suite.  I haven't tried doing it; there might
be conflicts with existing warning handlers in perhaps Moose, for
example.

To summarize, the bottom line is that the new commit in blead
008e8e82d7383361068156624879df7566121878 should cause the Org::Parser
test suite to now pass when run on a UTF-8 locale.  I see that the
original failure report came from such a locale

http://www.cpantesters.org/cpan/report/972d6b7e-905d-11e4-9c21-482a5ef060ad

These locales are increasingly common in newer Operating System releases
(my latest Linux box comes with only UTF-8 locales).  If the bug fixed
by 008e8e82d7383361068156624879df7566121878 hadn't existed, we might not
have known of this potential problem.

The problem has always existed, but was not warned about. This commit
hides the problem, and makes new Perl behave like old Perls.

An alternative to this commit is to do something with the test suite, as
outlined above.  If you decide you prefer that, let me know, and I will
write a patch accordingly.

Karl Williamson
khw@cpan.org