### PR TITLE
Typo in heading numbering

### DIFF
--- a/lib/Org/Element/Link.pm
+++ b/lib/Org/Element/Link.pm
@@ -52,7 +52,7 @@ Derived from L<Org::Element>.
 
 =head1 METHODS
 
-=head1 as_string => str
+=head2 as_string => str
 
 From L<Org::Element>.
 


### PR DESCRIPTION
`as_string => str` is erroneously shown as a level-1 heading, instead of being under `Methods`.  This also makes `as_text` appear in the wrong place.